### PR TITLE
docs: fix name order

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -2,7 +2,7 @@ Package: gutenbergr
 Title: Download and Process Public Domain Works from Project Gutenberg
 Version: 0.2.4.9000
 Authors@R: c(
-    person("Harmon", "Jon", , "jonthegeek@gmail.com", role = c("aut", "cre"),
+    person("Jon", "Harmon", , "jonthegeek@gmail.com", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0003-4781-4346")),
     person("Myfanwy", "Johnston", , "mrowlan1@gmail.com", role = "aut"),
     person("David", "Robinson", , "admiral.david@gmail.com", role = c("aut", "cph"))


### PR DESCRIPTION
I was looking at https://ropensci.r-universe.dev/builds#builds and noticed your name was inverted