### PR TITLE
Activate `testthat` 3e

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -33,7 +33,7 @@ Suggests:
     curl,
     knitr,
     rmarkdown,
-    testthat,
+    testthat (>= 3.0.0),
     tidyr,
     tidytext,
     withr
@@ -45,3 +45,4 @@ LazyData: TRUE
 LazyDataCompression: xz
 Roxygen: list(markdown = TRUE)
 RoxygenNote: 7.3.2
+Config/testthat/edition: 3

--- a/R/gutenberg_mirrors.R
+++ b/R/gutenberg_mirrors.R
@@ -73,7 +73,7 @@ gutenberg_get_mirror <- function(verbose = TRUE) {
 gutenberg_get_all_mirrors <- function() {
   mirrors_url <- "https://www.gutenberg.org/MIRRORS.ALL"
   mirrors <- suppressWarnings( # Table has extra row that causes vroom warning
-    readMDTable::read_md_table(mirrors_url, warn = FALSE) |>
+    readMDTable::read_md_table(mirrors_url, warn = FALSE, show_col_types = FALSE) |>
       dplyr::slice(2:(dplyr::n() - 1))
   )
 

--- a/tests/testthat/test-metadata.R
+++ b/tests/testthat/test-metadata.R
@@ -60,8 +60,8 @@ test_that("All four datasets have a date-updated", {
   d3 <- attr(gutenberg_authors, "date_updated")
   d4 <- attr(gutenberg_languages, "date_updated")
 
-  expect_is(d1, "Date")
-  expect_is(d2, "Date")
-  expect_is(d3, "Date")
-  expect_is(d4, "Date")
+  expect_s3_class(d1, "Date")
+  expect_s3_class(d2, "Date")
+  expect_s3_class(d3, "Date")
+  expect_s3_class(d4, "Date")
 })


### PR DESCRIPTION
Closes #79. 

- `expect_is` is deprecated in 3e, switched out for `expect_s3_class`
- added `show_col_types = FALSE` to `gutenberg_get_all_mirrors`, don't see much reason to show that output and it was showing up in the test output. I can always add a param to control this if you prefer