### PR TITLE
Resolve upcoming breaking change for `readMDTable::read_md_table()`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -16,20 +16,20 @@ License: GPL-2
 URL: https://docs.ropensci.org/gutenbergr/,
     https://github.com/ropensci/gutenbergr
 BugReports: https://github.com/ropensci/gutenbergr/issues
-Depends: 
+Depends:
     R (>= 4.1)
 Imports:
     cli,
     dplyr,
     glue,
     purrr,
-    readMDTable,
+    readMDTable (>= 0.3.0),
     readr,
     rlang,
     stringr,
     tibble,
     urltools
-Suggests: 
+Suggests:
     curl,
     knitr,
     rmarkdown,
@@ -37,7 +37,7 @@ Suggests:
     tidyr,
     tidytext,
     withr
-VignetteBuilder: 
+VignetteBuilder:
     knitr
 Encoding: UTF-8
 Language: en-US

--- a/R/gutenberg_mirrors.R
+++ b/R/gutenberg_mirrors.R
@@ -76,7 +76,7 @@ gutenberg_get_mirror <- function(verbose = TRUE) {
 gutenberg_get_all_mirrors <- function() {
   mirrors_url <- "https://www.gutenberg.org/MIRRORS.ALL"
   mirrors <- suppressWarnings( # Table has extra row that causes vroom warning
-    readMDTable::read_md_table(mirrors_url, warn = FALSE, show_col_types = FALSE) |>
+    readMDTable::read_md_table(mirrors_url, warn = FALSE, force = TRUE, show_col_types = FALSE) |>
       dplyr::slice(2:(dplyr::n() - 1))
   )
 

--- a/R/gutenberg_mirrors.R
+++ b/R/gutenberg_mirrors.R
@@ -76,8 +76,13 @@ gutenberg_get_mirror <- function(verbose = TRUE) {
 gutenberg_get_all_mirrors <- function() {
   mirrors_url <- "https://www.gutenberg.org/MIRRORS.ALL"
   mirrors <- suppressWarnings( # Table has extra row that causes vroom warning
-    readMDTable::read_md_table(mirrors_url, warn = FALSE, force = TRUE, show_col_types = FALSE) |>
-      dplyr::slice(2:(dplyr::n() - 1))
+    readMDTable::read_md_table(
+      mirrors_url,
+      warn = FALSE,
+      force = TRUE,
+      show_col_types = FALSE) |>
+      dplyr::slice(2:(dplyr::n() - 1)
+    )
   )
 
   return(mirrors)


### PR DESCRIPTION
Do not merge until {readMDTable} 0.3.0 is released on CRAN: https://github.com/jrdnbradford/readMDTable/issues/83.

The [GP mirrors table](https://www.gutenberg.org/MIRRORS.ALL) is a weird markdown variant with `+` separators and no leading/trailing `|`s, like below:

```md
 Name  | Age | City 
-------+-----+---------
 Alice | 30  | New York
 Bob   | 25  | Los Angeles
 Carol | 27  | Chicago
 ```

Currently the package will read this in, but after weighing options I decided to make this behavior non-default with a new `force` param.

I will comment when ready for merging, until added to CRAN tests will fail.
