### PR TITLE
Code of conduct fixes

### DIFF
--- a/.github/CODE_OF_CONDUCT.md
+++ b/.github/CODE_OF_CONDUCT.md
@@ -1,3 +1,5 @@
+# Code of Conduct
+
 English: Refer to [rOpenSci Code of Conduct](https://ropensci.org/code-of-conduct/).
 
 Español: Consulte el [Código de Conducta de rOpenSci](https://ropensci.org/es/c%C3%B3digo-de-conducta/).

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -40,5 +40,5 @@ See the Tidyverse guide on [how to create a great issue](https://code-review.tid
 
 ## Code of Conduct
 
-Please note that the gutenbergr project is released with [rOpenSci's Code of Conduct](https://ropensci.org/code-of-conduct/)
+Please note that the gutenbergr project is released with [rOpenSci's Code of Conduct](https://ropensci.org/code-of-conduct/).
 By contributing to this project you agree to abide by its terms.


### PR DESCRIPTION
This fixes a typo and an `NA` for the Code of Conduct heading.