### PR TITLE
Switch `quiet` param to `verbose`

### DIFF
--- a/R/gutenberg_cache.R
+++ b/R/gutenberg_cache.R
@@ -64,14 +64,14 @@ gutenberg_cache_files <- function() {
 #'     user cache directory. These files persist across sessions,
 #'     preventing redundant downloads of the same files in the future.
 #'  }
-#' @param quiet Whether to suppress the status message confirming the path.
+#' @param verbose Whether to show the status message confirming the path.
 #'
 #' @return The active cache path (invisibly).
 #' @export
 #' @keywords cache
 gutenberg_set_cache <- function(
   type = c("session", "persistent"),
-  quiet = FALSE
+  verbose = TRUE
 ) {
   type <- match.arg(type)
   options(gutenbergr_cache_type = type)
@@ -85,7 +85,7 @@ gutenberg_set_cache <- function(
 
   gutenberg_ensure_cache_dir()
   path <- gutenberg_cache_dir()
-  if (!quiet) {
+  if (verbose) {
     cli::cli_alert_success("Cache set to {.val {type}}: {.path {path}}")
   }
 
@@ -116,12 +116,12 @@ gutenberg_clear_cache <- function() {
 #'
 #' @param ids A numeric or character vector of Gutenberg IDs to remove
 #'   from the current cache.
-#' @param quiet Whether to suppress the status messages.
+#' @param verbose Whether to show the status messages.
 #'
 #' @return The number of files successfully deleted (invisibly).
 #' @keywords cache
 #' @export
-gutenberg_delete_cache <- function(ids, quiet = FALSE) {
+gutenberg_delete_cache <- function(ids, verbose = TRUE) {
   if (missing(ids) || length(ids) == 0) {
     cli::cli_abort("Please provide at least one Gutenberg ID to delete.")
   }
@@ -133,13 +133,13 @@ gutenberg_delete_cache <- function(ids, quiet = FALSE) {
 
   if (n_deleted > 0) {
     unlink(existing_files)
-    if (!quiet) {
+    if (verbose) {
       cli::cli_alert_success(
         "Deleted {n_deleted} cached file{?s} from {.path {cache_root}}"
       )
     }
   } else {
-    if (!quiet) {
+    if (verbose) {
       cli::cli_alert_info(
         "None of the specified IDs ({.val {ids}}) were found in the current cache."
       )
@@ -154,7 +154,7 @@ gutenberg_delete_cache <- function(ids, quiet = FALSE) {
 #' Provides a detailed list of files currently stored in the directory
 #' returned by [gutenberg_cache_dir()].
 #'
-#' @param quiet Whether to suppress the status message showing the cache directory path.
+#' @param verbose Whether to show the status message showing the cache directory path.
 #'
 #' @return A [tibble::tibble] with the following columns:
 #'   \describe{
@@ -165,11 +165,11 @@ gutenberg_delete_cache <- function(ids, quiet = FALSE) {
 #'   }
 #' @keywords cache
 #' @export
-gutenberg_list_cache <- function(quiet = FALSE) {
+gutenberg_list_cache <- function(verbose = TRUE) {
   cache_root <- gutenberg_cache_dir()
   files <- gutenberg_cache_files()
 
-  if (!quiet) {
+  if (verbose) {
     cli::cli_inform("Cache directory: {.path {cache_root}}")
   }
 

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -5,7 +5,7 @@
     cache_type <- "session"
   }
 
-  gutenberg_set_cache(cache_type, quiet = TRUE)
+  gutenberg_set_cache(cache_type, verbose = FALSE)
   gutenberg_ensure_cache_dir()
   invisible()
 }

--- a/man/gutenberg_delete_cache.Rd
+++ b/man/gutenberg_delete_cache.Rd
@@ -4,13 +4,13 @@
 \alias{gutenberg_delete_cache}
 \title{Delete specific files from the cache}
 \usage{
-gutenberg_delete_cache(ids, quiet = FALSE)
+gutenberg_delete_cache(ids, verbose = TRUE)
 }
 \arguments{
 \item{ids}{A numeric or character vector of Gutenberg IDs to remove
 from the current cache.}
 
-\item{quiet}{Whether to suppress the status messages.}
+\item{verbose}{Whether to show the status messages.}
 }
 \value{
 The number of files successfully deleted (invisibly).

--- a/man/gutenberg_list_cache.Rd
+++ b/man/gutenberg_list_cache.Rd
@@ -4,10 +4,10 @@
 \alias{gutenberg_list_cache}
 \title{List files in the Gutenberg cache}
 \usage{
-gutenberg_list_cache(quiet = FALSE)
+gutenberg_list_cache(verbose = TRUE)
 }
 \arguments{
-\item{quiet}{Whether to suppress the status message showing the cache directory path.}
+\item{verbose}{Whether to show the status message showing the cache directory path.}
 }
 \value{
 A \link[tibble:tibble]{tibble::tibble} with the following columns:

--- a/man/gutenberg_set_cache.Rd
+++ b/man/gutenberg_set_cache.Rd
@@ -4,7 +4,7 @@
 \alias{gutenberg_set_cache}
 \title{Set the Gutenberg cache type}
 \usage{
-gutenberg_set_cache(type = c("session", "persistent"), quiet = FALSE)
+gutenberg_set_cache(type = c("session", "persistent"), verbose = TRUE)
 }
 \arguments{
 \item{type}{Either \code{"session"} (default) or \code{"persistent"}.
@@ -16,7 +16,7 @@ user cache directory. These files persist across sessions,
 preventing redundant downloads of the same files in the future.
 }}
 
-\item{quiet}{Whether to suppress the status message confirming the path.}
+\item{verbose}{Whether to show the status message confirming the path.}
 }
 \value{
 The active cache path (invisibly).

--- a/tests/testthat/test-gutenberg_cache.R
+++ b/tests/testthat/test-gutenberg_cache.R
@@ -34,7 +34,7 @@ describe("gutenberg_cache_dir()", {
 describe("gutenberg_set_cache()", {
   test_that("session mode uses tempdir()", {
     with_gutenberg_cache({
-      path <- gutenberg_set_cache("session", quiet = TRUE)
+      path <- gutenberg_set_cache("session", verbose = FALSE)
       expect_true(
         startsWith(
           normalizePath(path, mustWork = FALSE),
@@ -47,14 +47,14 @@ describe("gutenberg_set_cache()", {
 
   test_that("persistent mode returns default cache", {
     with_gutenberg_cache({
-      path <- gutenberg_set_cache("persistent", quiet = TRUE)
+      path <- gutenberg_set_cache("persistent", verbose = FALSE)
       expect_type(path, "character")
     })
   })
 
   test_that("toggles between different paths", {
     with_gutenberg_cache({
-      session_path <- gutenberg_set_cache("session", quiet = TRUE)
+      session_path <- gutenberg_set_cache("session", verbose = FALSE)
 
       # Define a separate, writable temp path for the mock persistent storage
       mock_persistent_path <- tempfile("mock_persistent_")
@@ -71,7 +71,7 @@ describe("gutenberg_set_cache()", {
         .package = "dlr"
       )
 
-      persistent_path <- gutenberg_set_cache("persistent", quiet = TRUE)
+      persistent_path <- gutenberg_set_cache("persistent", verbose = FALSE)
       expect_false(identical(session_path, persistent_path))
       expect_equal(persistent_path, mock_persistent_path)
       expect_true(dir.exists(persistent_path))
@@ -80,7 +80,7 @@ describe("gutenberg_set_cache()", {
 
   test_that("session cache is detected as temporary", {
     with_gutenberg_cache({
-      gutenberg_set_cache("session", quiet = TRUE)
+      gutenberg_set_cache("session", verbose = FALSE)
       path <- gutenberg_cache_dir()
 
       is_session <- startsWith(
@@ -92,10 +92,10 @@ describe("gutenberg_set_cache()", {
     })
   })
 
-  test_that("emits success message when quiet = FALSE", {
+  test_that("emits success message when verbose = TRUE", {
     with_gutenberg_cache({
       expect_message(
-        gutenberg_set_cache("session", quiet = FALSE),
+        gutenberg_set_cache("session", verbose = TRUE),
         "Cache set to"
       )
     })
@@ -105,7 +105,7 @@ describe("gutenberg_set_cache()", {
 describe("gutenberg_list_cache()", {
   test_that("returns empty tibble when cache is empty", {
     with_gutenberg_cache({
-      out <- gutenberg_list_cache(quiet = TRUE)
+      out <- gutenberg_list_cache(verbose = FALSE)
       expect_s3_class(out, "tbl_df")
       expect_equal(nrow(out), 0)
     })
@@ -117,7 +117,7 @@ describe("gutenberg_list_cache()", {
       saveRDS("test", file.path(path, "123.rds"))
       saveRDS("test", file.path(path, "456.rds"))
 
-      out <- gutenberg_list_cache(quiet = TRUE)
+      out <- gutenberg_list_cache(verbose = FALSE)
 
       expect_equal(nrow(out), 2)
       expect_true(all(out$file %in% c("123.rds", "456.rds")))
@@ -125,10 +125,10 @@ describe("gutenberg_list_cache()", {
     })
   })
 
-  test_that("informs about directory when quiet = FALSE", {
+  test_that("informs about directory when verbose = TRUE", {
     with_gutenberg_cache({
       expect_message(
-        gutenberg_list_cache(quiet = FALSE),
+        gutenberg_list_cache(verbose = TRUE),
         "Cache directory:"
       )
     })
@@ -144,7 +144,7 @@ describe("gutenberg_delete_cache()", {
       saveRDS(list(id = 105), file_105)
       saveRDS(list(id = 109), file_109)
 
-      n <- gutenberg_delete_cache(105, quiet = TRUE)
+      n <- gutenberg_delete_cache(105, verbose = FALSE)
       expect_equal(n, 1)
       expect_false(file.exists(file_105))
       expect_true(file.exists(file_109))
@@ -160,18 +160,18 @@ describe("gutenberg_delete_cache()", {
     })
   })
 
-  test_that("messages on success and missing when quiet = FALSE", {
+  test_that("messages on success and missing when verbose = TRUE", {
     with_gutenberg_cache({
       path <- gutenberg_cache_dir()
       saveRDS(list(id = 1), file.path(path, "1.rds"))
 
       expect_message(
-        gutenberg_delete_cache(1, quiet = FALSE),
+        gutenberg_delete_cache(1, verbose = TRUE),
         "Deleted 1 cached file"
       )
 
       expect_message(
-        gutenberg_delete_cache(999, quiet = FALSE),
+        gutenberg_delete_cache(999, verbose = TRUE),
         "None of the specified IDs"
       )
     })

--- a/tests/testthat/test-gutenberg_download.R
+++ b/tests/testthat/test-gutenberg_download.R
@@ -62,6 +62,6 @@ test_that("gutenberg_download actually caches a file", {
 
     cache_path <- gutenberg_cache_dir()
     expect_true(file.exists(file.path(cache_path, "109.rds")))
-    expect_equal(nrow(gutenberg_list_cache(quiet = TRUE)), 1)
+    expect_equal(nrow(gutenberg_list_cache(verbose = FALSE)), 1)
   })
 })


### PR DESCRIPTION
gutenbergr uses `verbose` in several spots already, this switches `quiet` in the new caching features for consistency.