### PR TITLE
Improve cache use, testing, options

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -15,13 +15,13 @@ Description: Download and process public domain works in the Project
     retrieved.
 License: GPL-2
 URL: https://docs.ropensci.org/gutenbergr/,
+     https://ropensci.r-universe.dev/gutenbergr,
      https://github.com/ropensci/gutenbergr
 BugReports: https://github.com/ropensci/gutenbergr/issues
 Depends:
     R (>= 4.1)
 Imports:
     cli,
-    dlr,
     dplyr,
     glue,
     purrr,

--- a/R/data.R
+++ b/R/data.R
@@ -40,7 +40,7 @@
 #' gutenberg_metadata |>
 #'   count(author, sort = TRUE)
 #'
-#' # look for Shakespeare, excluding collections (containing "Works") and
+#' # Look for Shakespeare, excluding collections (containing "Works") and
 #' # translations
 #' shakespeare_metadata <- gutenberg_metadata |>
 #'   filter(
@@ -52,7 +52,7 @@
 #'   ) |>
 #'   distinct(title)
 #'
-#' # note that the gutenberg_works() function filters for English
+#' # Note that the gutenberg_works() function filters for English
 #' # non-copyrighted works and does de-duplication by default:
 #'
 #' shakespeare_metadata2 <- gutenberg_works(
@@ -60,7 +60,7 @@
 #'   !str_detect(title, "Works")
 #' )
 #'
-#' # date last updated
+#' # See date last updated
 #' attr(gutenberg_metadata, "date_updated")
 #'
 #' @seealso [gutenberg_works()], [gutenberg_authors], [gutenberg_subjects]
@@ -119,7 +119,7 @@
 #' holmes_books
 #' }
 #'
-#' # date last updated
+#' # See date last updated
 #' attr(gutenberg_subjects, "date_updated")
 #'
 #' @seealso [gutenberg_metadata], [gutenberg_authors]
@@ -156,7 +156,7 @@
 #'
 #' @examples
 #'
-#' # date last updated
+#' # See date last updated
 #' attr(gutenberg_authors, "date_updated")
 #'
 #' @seealso [gutenberg_metadata], [gutenberg_subjects]
@@ -184,7 +184,7 @@
 #'
 #' @examples
 #'
-#' # date last updated
+#' # See date last updated
 #' attr(gutenberg_languages, "date_updated")
 #'
 #' @seealso [gutenberg_metadata], [gutenberg_subjects]

--- a/R/gutenberg_download.R
+++ b/R/gutenberg_download.R
@@ -58,14 +58,19 @@ gutenberg_download <- function(
   urls <- gutenberg_url(gutenberg_id, mirror, verbose)
   downloaded <- purrr::imap(urls, function(url, id) {
     if (use_cache) {
-      dlr::read_or_cache(
-        source_path = id,
-        appname = "gutenbergr",
-        filename = paste0(id, ".rds"),
-        process_f = function(x) {
-          try_gutenberg_download(url)
+      cache_dir <- gutenberg_cache_dir()
+      cache_file <- file.path(cache_dir, paste0(id, ".rds"))
+
+      if (file.exists(cache_file)) {
+        readRDS(cache_file)
+      } else {
+        result <- try_gutenberg_download(url)
+        if (!is.null(result)) {
+          gutenberg_ensure_cache_dir()
+          saveRDS(result, cache_file)
         }
-      )
+        result
+      }
     } else {
       try_gutenberg_download(url)
     }

--- a/man/gutenberg_authors.Rd
+++ b/man/gutenberg_authors.Rd
@@ -36,7 +36,7 @@ run \code{attr(gutenberg_authors, "date_updated")}.
 }
 \examples{
 
-# date last updated
+# See date last updated
 attr(gutenberg_authors, "date_updated")
 
 }

--- a/man/gutenberg_cache_clear_all.Rd
+++ b/man/gutenberg_cache_clear_all.Rd
@@ -4,7 +4,10 @@
 \alias{gutenberg_cache_clear_all}
 \title{Clear all files from the Gutenberg cache}
 \usage{
-gutenberg_cache_clear_all()
+gutenberg_cache_clear_all(verbose = TRUE)
+}
+\arguments{
+\item{verbose}{Whether to show the status message confirming the path.}
 }
 \value{
 The number of files deleted (invisibly).

--- a/man/gutenberg_cache_dir.Rd
+++ b/man/gutenberg_cache_dir.Rd
@@ -11,8 +11,23 @@ A character string representing the path to the cache directory.
 }
 \description{
 Calculates the path to the directory where Gutenberg files are stored,
-based on the current \code{gutenbergr_cache_type} option.
+based on the current \code{gutenbergr_cache_type} and \code{gutenbergr_base_cache_dir}
+options.
 }
+\section{Cache options}{
+
+The following options control caching behavior:
+\itemize{
+\item \code{gutenbergr_cache_type}: Character string indicating how downloaded works
+are cached. Must be either \code{"session"} (default) or \code{"persistent"}.
+\item \code{gutenbergr_base_cache_dir}: Base directory used for persistent caching when
+\code{gutenbergr_cache_type = "persistent"}.
+By default, this is an OS-specific cache directory determined by
+\code{tools::R_user_dir("gutenbergr", "cache")}. Advanced users may set this
+to a custom path.
+}
+}
+
 \examples{
 \dontshow{if (interactive()) withAutoprint(\{ # examplesIf}
 # Get current cache directory

--- a/man/gutenberg_cache_set.Rd
+++ b/man/gutenberg_cache_set.Rd
@@ -15,7 +15,7 @@ gutenberg_cache_set(
 \item \code{"session"}: Files are stored in a \code{\link[=tempdir]{tempdir()}}.
 This is the default behavior.
 \item \code{"persistent"}: Files are stored in an OS-specific
-user cache directory. These files persist across sessions,
+user cache directory under \verb{works_rds/}. These files persist across sessions,
 preventing redundant downloads of the same files in the future.
 }}
 
@@ -28,10 +28,20 @@ The active cache path (invisibly).
 Configures whether the cache should be temporary (per-session) or
 persistent across sessions.
 }
-\details{
-The cache type can also be set with an option:
-\code{options(gutenbergr_cache_type = "persistent")}
+\section{Cache options}{
+
+The following options control caching behavior:
+\itemize{
+\item \code{gutenbergr_cache_type}: Character string indicating how downloaded works
+are cached. Must be either \code{"session"} (default) or \code{"persistent"}.
+\item \code{gutenbergr_base_cache_dir}: Base directory used for persistent caching when
+\code{gutenbergr_cache_type = "persistent"}.
+By default, this is an OS-specific cache directory determined by
+\code{tools::R_user_dir("gutenbergr", "cache")}. Advanced users may set this
+to a custom path.
 }
+}
+
 \examples{
 \dontshow{if (interactive()) withAutoprint(\{ # examplesIf}
 # Set to persistent (survives R sessions)

--- a/man/gutenberg_languages.Rd
+++ b/man/gutenberg_languages.Rd
@@ -28,7 +28,7 @@ run \code{attr(gutenberg_languages, "date_updated")}.
 }
 \examples{
 
-# date last updated
+# See date last updated
 attr(gutenberg_languages, "date_updated")
 
 }

--- a/man/gutenberg_metadata.Rd
+++ b/man/gutenberg_metadata.Rd
@@ -49,7 +49,7 @@ gutenberg_metadata
 gutenberg_metadata |>
   count(author, sort = TRUE)
 
-# look for Shakespeare, excluding collections (containing "Works") and
+# Look for Shakespeare, excluding collections (containing "Works") and
 # translations
 shakespeare_metadata <- gutenberg_metadata |>
   filter(
@@ -61,7 +61,7 @@ shakespeare_metadata <- gutenberg_metadata |>
   ) |>
   distinct(title)
 
-# note that the gutenberg_works() function filters for English
+# Note that the gutenberg_works() function filters for English
 # non-copyrighted works and does de-duplication by default:
 
 shakespeare_metadata2 <- gutenberg_works(
@@ -69,7 +69,7 @@ shakespeare_metadata2 <- gutenberg_works(
   !str_detect(title, "Works")
 )
 
-# date last updated
+# See date last updated
 attr(gutenberg_metadata, "date_updated")
 \dontshow{\}) # examplesIf}
 }

--- a/man/gutenberg_subjects.Rd
+++ b/man/gutenberg_subjects.Rd
@@ -59,7 +59,7 @@ holmes_books <- gutenberg_download(sherlock_holmes_metadata$gutenberg_id)
 holmes_books
 }
 
-# date last updated
+# See date last updated
 attr(gutenberg_subjects, "date_updated")
 \dontshow{\}) # examplesIf}
 }

--- a/man/gutenbergr-package.Rd
+++ b/man/gutenbergr-package.Rd
@@ -12,6 +12,7 @@ Download and process public domain works in the Project Gutenberg collection \ur
 Useful links:
 \itemize{
   \item \url{https://docs.ropensci.org/gutenbergr/}
+  \item \url{https://ropensci.r-universe.dev/gutenbergr}
   \item \url{https://github.com/ropensci/gutenbergr}
   \item Report bugs at \url{https://github.com/ropensci/gutenbergr/issues}
 }

--- a/tests/testthat/helper-cache.R
+++ b/tests/testthat/helper-cache.R
@@ -1,37 +1,20 @@
-# Provides test-safe cache locations
+# Provides test-safe cache locations and options
 with_gutenberg_cache <- function(code, type = "persistent") {
-  # Mock the prompt inside the dlr package call to utils::askYesNo
-  testthat::local_mocked_bindings(
-    askYesNo = function(...) TRUE,
-    .package = "utils"
+  withr::local_options(
+    gutenbergr_cache_type = type
   )
 
-  old_type <- getOption("gutenbergr_cache_type")
-  old_path <- dlr::app_cache_dir("gutenbergr")
-
   if (type == "persistent") {
-    tmp <- tempfile("gutenbergr-test-")
-    dir.create(tmp, recursive = TRUE)
-    options(gutenbergr_cache_type = "persistent")
-    dlr::set_app_cache_dir("gutenbergr", cache_dir = tmp)
+    cache_root <- withr::local_tempdir("gutenbergr-test-")
 
-    on.exit(
-      {
-        options(gutenbergr_cache_type = old_type)
-        dlr::set_app_cache_dir("gutenbergr", cache_dir = old_path)
-        unlink(tmp, recursive = TRUE)
-      },
-      add = TRUE
+    withr::local_options(
+      gutenbergr_base_cache_dir = cache_root
     )
-  } else {
-    options(gutenbergr_cache_type = "session")
 
-    on.exit(
-      {
-        options(gutenbergr_cache_type = old_type)
-        dlr::set_app_cache_dir("gutenbergr", cache_dir = old_path)
-      },
-      add = TRUE
+    gutenberg_ensure_cache_dir()
+  } else {
+    withr::local_options(
+      gutenbergr_base_cache_dir = NULL
     )
   }
 

--- a/tests/testthat/test-zzz.R
+++ b/tests/testthat/test-zzz.R
@@ -24,17 +24,22 @@ describe(".onLoad()", {
           .onLoad(NULL, NULL),
           "Invalid gutenbergr_cache_type.*Defaulting to"
         )
+
+        expect_identical(
+          getOption("gutenbergr_cache_type"),
+          "session"
+        )
+
+        path <- gutenberg_cache_dir()
+        expect_true(
+          startsWith(
+            normalizePath(path, mustWork = FALSE),
+            normalizePath(tempdir(), mustWork = FALSE)
+          )
+        )
       },
       type = "session"
     )
-
-    path <- gutenberg_cache_dir()
-    expect_true(startsWith(
-      normalizePath(path, mustWork = FALSE),
-      normalizePath(tempdir(), mustWork = FALSE)
-    ))
-
-    expect_identical(getOption("gutenbergr_cache_type"), "session")
   })
 })
 


### PR DESCRIPTION
Major updates to caching setup:

- removed `dlr` in favor of `tools::R_user_dir()` available in R >= 4.
- adds a `works_rds` subdirectory in the cache directory in case we need to cache different files in the future
- improved testing, including adding a test that ensures the tester's actual cache directory isn't touched by other tests and improving the `with_gutenberg_cache` function