### PR TITLE
Startup message only if `interactive()`

### DIFF
--- a/R/zzz.R
+++ b/R/zzz.R
@@ -3,20 +3,18 @@
   gutenberg_ensure_cache_dir()
 }
 
-.onAttach <- function(libname, pkgname) {
-  if (!interactive()) {
+.onAttach <- function(libname, pkgname, interactive_session = interactive()) {
+  if (!interactive_session) {
     return(invisible())
   }
 
   path <- gutenberg_cache_dir()
   type <- getOption("gutenbergr_cache_type", "session")
-
   type_str <- if (type == "session") {
     "session (temporary)"
   } else {
     "persistent"
   }
-
   packageStartupMessage(
     "gutenbergr: using ",
     type_str,
@@ -24,6 +22,5 @@
     "  cache directory: ",
     path
   )
-
   invisible()
 }

--- a/tests/testthat/helper-interactive.R
+++ b/tests/testthat/helper-interactive.R
@@ -1,7 +1,0 @@
-local_interactive <- function(value, env = parent.frame()) {
-  testthat::local_mocked_bindings(
-    interactive = function() value,
-    .package = "base",
-    .env = env
-  )
-}

--- a/tests/testthat/test-zzz.R
+++ b/tests/testthat/test-zzz.R
@@ -46,14 +46,13 @@ describe(".onLoad()", {
 describe(".onAttach()", {
   test_that("shows session cache message when type is session", {
     with_gutenberg_cache(type = "session", {
-      local_interactive(TRUE)
       expect_message(
-        .onAttach(NULL, NULL),
+        .onAttach(NULL, NULL, interactive_session = TRUE),
         "session \\(temporary\\)"
       )
       path <- gutenberg_cache_dir()
       expect_message(
-        .onAttach(NULL, NULL),
+        .onAttach(NULL, NULL, interactive_session = TRUE),
         path,
         fixed = TRUE
       )
@@ -63,17 +62,14 @@ describe(".onAttach()", {
   test_that("shows persistent cache message when type is persistent", {
     with_gutenberg_cache(type = "persistent", {
       testthat::local_mocked_bindings(
-        gutenberg_cache_dir = function() "/fake/persistent/path",
-        .package = "gutenbergr"
+        gutenberg_cache_dir = function() "/fake/persistent/path"
       )
-      local_interactive(TRUE)
-
       expect_message(
-        .onAttach(NULL, NULL),
+        .onAttach(NULL, NULL, interactive_session = TRUE),
         "persistent"
       )
       expect_message(
-        .onAttach(NULL, NULL),
+        .onAttach(NULL, NULL, interactive_session = TRUE),
         "/fake/persistent/path",
         fixed = TRUE
       )
@@ -82,9 +78,8 @@ describe(".onAttach()", {
 
   test_that("message contains 'gutenbergr: using' prefix", {
     with_gutenberg_cache({
-      local_interactive(TRUE)
       expect_message(
-        .onAttach(NULL, NULL),
+        .onAttach(NULL, NULL, interactive_session = TRUE),
         "gutenbergr: using"
       )
     })
@@ -92,9 +87,8 @@ describe(".onAttach()", {
 
   test_that("message contains 'cache directory:' label", {
     with_gutenberg_cache({
-      local_interactive(TRUE)
       expect_message(
-        .onAttach(NULL, NULL),
+        .onAttach(NULL, NULL, interactive_session = TRUE),
         "cache directory:"
       )
     })
@@ -102,9 +96,8 @@ describe(".onAttach()", {
 
   test_that("no message shown in non-interactive mode", {
     with_gutenberg_cache({
-      local_interactive(FALSE)
       expect_silent(
-        .onAttach(NULL, NULL)
+        .onAttach(NULL, NULL, interactive_session = FALSE)
       )
     })
   })


### PR DESCRIPTION
Prevents the cache message from appearing in CI and other non-interactive contexts.