### PR TITLE
Document new `NULL` return for `gutenberg_get_all_mirrors`

### DIFF
--- a/R/gutenberg_mirrors.R
+++ b/R/gutenberg_mirrors.R
@@ -91,7 +91,10 @@ gutenberg_get_mirror <- function(verbose = TRUE) {
 #' relatively stable. For more information on mirroring and getting your own
 #' mirror listed, see <https://www.gutenberg.org/help/mirroring.html>.
 #'
-#' @return A [tibble::tibble()] of Project Gutenberg mirrors and related data:
+#' @return A [tibble::tibble()] of Project Gutenberg mirrors and related data,
+#' or `NULL` (invisibly) if the mirror list cannot be retrieved or parsed.
+#'
+#' If a [tibble::tibble()] is returned, it contains:
 #' \describe{
 #'   \item{continent}{Continent where the mirror is located}
 #'   \item{nation}{Nation where the mirror is located}

--- a/man/gutenberg_get_all_mirrors.Rd
+++ b/man/gutenberg_get_all_mirrors.Rd
@@ -7,7 +7,10 @@
 gutenberg_get_all_mirrors()
 }
 \value{
-A \code{\link[tibble:tibble]{tibble::tibble()}} of Project Gutenberg mirrors and related data:
+A \code{\link[tibble:tibble]{tibble::tibble()}} of Project Gutenberg mirrors and related data,
+or \code{NULL} (invisibly) if the mirror list cannot be retrieved or parsed.
+
+If a \code{\link[tibble:tibble]{tibble::tibble()}} is returned, it contains:
 \describe{
 \item{continent}{Continent where the mirror is located}
 \item{nation}{Nation where the mirror is located}


### PR DESCRIPTION
`NULL` is now returned in some contexts since #132. 